### PR TITLE
Stop getting [state]_all_bills for every state parliament Bill object instance

### DIFF
--- a/ausbills/act_parliament.py
+++ b/ausbills/act_parliament.py
@@ -152,8 +152,6 @@ class All_Bills(object):
 act_all_bills = All_Bills().data
 
 class act_Bill(object):
-    _all_bills = act_all_bills
-
     def __init__(self, input):
         if(isinstance(input, dict)):
             try:

--- a/ausbills/nt_parliament.py
+++ b/ausbills/nt_parliament.py
@@ -48,8 +48,6 @@ class nt_All_Bills(object):
 nt_all_bills = nt_All_Bills().data
 
 class nt_Bill(object):
-    _nt_all_bills = nt_all_bills
-
     def __init__(self, input):
         if(isinstance(input, dict)):
             try:

--- a/ausbills/qld_parliament.py
+++ b/ausbills/qld_parliament.py
@@ -55,8 +55,6 @@ class qld_All_Bills(object):
 qld_all_bills = qld_All_Bills().data
 
 class qld_Bill(object):
-    _all_bills = qld_all_bills
-
     def __init__(self, input):
         if(isinstance(input, dict)):
             try:

--- a/ausbills/sa_parliament.py
+++ b/ausbills/sa_parliament.py
@@ -42,8 +42,6 @@ class sa_All_Bills(object):
 sa_all_bills = sa_All_Bills().data
 
 class sa_Bill(object):
-    _all_bills = sa_all_bills
-
     def __init__(self, input):
         if(isinstance(input, dict)):
             try:

--- a/ausbills/tas_parliament.py
+++ b/ausbills/tas_parliament.py
@@ -53,8 +53,6 @@ class tas_All_Bills(object):
 tas_all_bills = tas_All_Bills().data
 
 class tas_Bill(object):
-    _all_bills = tas_all_bills
-
     def __init__(self, input):
         if(isinstance(input, dict)):
             try:


### PR DESCRIPTION
Speeds things up a bit for the state/territory parliaments.